### PR TITLE
Add support proto3 syntax. Fix structure name generation.

### DIFF
--- a/extension-proto.cpp.mtl
+++ b/extension-proto.cpp.mtl
@@ -34,10 +34,10 @@ static void lua_push{{type_cpp_lower}}(lua_State* L, {{type_cpp}} *msg)
     {{#properties}}
     {{#repeated}}
     // {{name}}
-    lua_pushstring(L, "{{name}}");
+    lua_pushstring(L, "{{name_cpp_lower}}");
     lua_newtable(L);
-    int {{name}}_size = msg->n_{{name}};
-    for (int i = 0; i < {{name}}_size; i++)
+    int {{name_cpp_lower}}_size = msg->n_{{name_cpp_lower}};
+    for (int i = 0; i < {{name_cpp_lower}}_size; i++)
     {
         lua_pushnumber(L, i + 1);
         lua_push{{type_lua}}(L, ({{type_cpp}})(msg->{{name_cpp_lower}}[i]));
@@ -53,6 +53,7 @@ static void lua_push{{type_cpp_lower}}(lua_State* L, {{type_cpp}} *msg)
     lua_settable(L, -3);
 
     {{/required}}
+    {{#is_proto2_syntax}}
     {{#optional}}
     // {{name}}
     if ({{#type_is_primitive}}msg->has_{{name_cpp_lower}}{{/type_is_primitive}}{{#type_is_string}}msg->{{name_cpp_lower}} != 0{{/type_is_string}}{{#type_is_bytes}}msg->{{name_cpp_lower}}.data != 0{{/type_is_bytes}}{{#type_is_message}}msg->{{name_cpp_lower}} != 0{{/type_is_message}})
@@ -63,6 +64,7 @@ static void lua_push{{type_cpp_lower}}(lua_State* L, {{type_cpp}} *msg)
     }
 
     {{/optional}}
+    {{/is_proto2_syntax}}
     {{/properties}}
 }
 {{/messages}}
@@ -133,9 +135,11 @@ static {{type_cpp}}* luaL_check{{type_cpp_lower}}(lua_State* L, int narg)
     lua_gettable(L, narg);
     if (!lua_isnil(L, lua_gettop(L)))
     {
+        {{#is_proto2_syntax}}
         {{#type_is_primitive}}
         msg->has_{{name_cpp_lower}} = 1;
         {{/type_is_primitive}}
+        {{/is_proto2_syntax}}
         msg->{{name_cpp_lower}} = ({{type_cpp}})luaL_check{{type_lua}}(L, lua_gettop(L));
     }
     lua_pop(L, 1);

--- a/plugins/protoc-gen-json.py
+++ b/plugins/protoc-gen-json.py
@@ -36,6 +36,9 @@ def traverse(proto_file):
         _traverse(proto_file.package, proto_file.message_type),
     )
 
+def capitalize_first_letter_only(input):
+  return re.sub('([a-zA-Z])', lambda x: x.groups()[0].upper(), input, 1)
+
 def camel_to_snake(s):
     words = re.findall(r'[A-Z]*[a-z\d]*', s)
     while('' in words):
@@ -68,7 +71,7 @@ def type_name_to_cpp(type_name, lower=False, upper=False):
         else:
             # dmInputDDF GamepadModifier_t -> DmInputDDF__GamepadModifierT
             name_words = name.split('_')
-            name = name_words[0] + ''.join(n.title() for n in name_words[1:])
+            name = name_words[0] + ''.join(capitalize_first_letter_only(n) for n in name_words[1:])
             name = name[0].upper() + name[1:]
         type_name_parts.append(name)
     return "__".join(type_name_parts)
@@ -99,6 +102,7 @@ def generate_code(request, response):
             parent_name = parent.name if parent else None
             item_type_name = package + "." + (parent_name + "." if parent_name else "") + item_name
             data = {
+                "is_proto2_syntax": proto_file.syntax == "proto2",
                 "package": package,
                 "package_lower": package.lower(),
                 "nested": '.' in package,


### PR DESCRIPTION
# proto3 syntax support added
When protoc generate code from proto files with "proto3 syntax" definition generated code doesn't contain any function and field like 'has_<field>'.

# Error in structure name
Function `type_name_to_cpp` produce incorrect output for names like `SomeCamelCase_MixedCase`  which lead to compiler error. So `capitalize_first_letter_only` was added to fix generation result.